### PR TITLE
Fixing "displaySubjectValues()" expecting array getting int

### DIFF
--- a/view/omeka/site/item/show.phtml
+++ b/view/omeka/site/item/show.phtml
@@ -56,8 +56,15 @@ foreach ($itemMedia as $media) {
 <?php endif; ?>
 <?php
 $page = $this->params()->fromQuery('page', 1);
+$perPage = 25;
 $property = $this->params()->fromQuery('property');
-$subjectValues = $item->displaySubjectValues($page, 25, $property);
+
+$options = [
+    "page" => $page,
+    "perPage" => $perPage,
+    "property" => $property,
+];
+$subjectValues = $item->displaySubjectValues($options);
 ?>
 <?php if ($subjectValues): ?>
 <div id="item-linked">


### PR DESCRIPTION
Hi,

On a project i'm managing which uses your theme, we started getting an error following an update (version 4.1.1):

```
 TypeError

Argument 1 passed to
Omeka\Api\Representation\AbstractResourceEntityRepresentation::displaySubjectValues()
 must be of the type array, int given, called in
/var/www/omeka-s/themes/HearingTheAmericas/view/omeka/site/item/show.phtml
 on line 61
Détails :
TypeError: Argument 1 passed to
Omeka\Api\Representation\AbstractResourceEntityRepresentation::displaySubjectValues()
must be of the type array, int given, called in
/var/www/omeka-s/themes/HearingTheAmericas/view/omeka/site/item/show.phtml
on line 61 and defined in
/var/www/omeka-s/application/src/Api/Representation/AbstractResourceEntityRepresentation.php:541
```
There was a mismatch between the theme, which used:

/var/www/omeka-s/themes/HearingTheAmericas/view/omeka/site/item/show.phtml:

```php
$subjectValues = $item->displaySubjectValues($page, 25, $property);
```

And omeka-s, which since commit [54fe81a](https://github.com/omeka/omeka-s/commit/54fe81aff52d57ebb73f9228a223d8f7d8cca2ba) expects an array:

/var/www/omeka-s/application/src/Api/Representation/AbstractResourceEntityRepresentation.php:

```php
 public function displaySubjectValues(array $options = [])
```

I changed the theme as best as I could, given that I'm not a PHP developer

```php
$options = [
    "page" => $page,
    "perPage" => $perPage,
    "property" => $property,
];

$subjectValues = $item->displaySubjectValues($options);
```

It now works, but given that the omeka-s commit seem to be a fairly big change, other side effects might be expected.